### PR TITLE
Removes strong references to self in blocks

### DIFF
--- a/LRImageManager/LRImageCache.m
+++ b/LRImageManager/LRImageCache.m
@@ -96,7 +96,9 @@ static NSString *const kImageCacheDirectoryName = @"LRImageCache";
     
     __block UIImage *memCachedImage = nil;
     
+	__weak typeof(self) _weak_self = self;
     dispatch_sync(self.syncQueue, ^{
+		__strong typeof(_weak_self) self = _weak_self;
         memCachedImage = self.imagesDictionary[key] ?:
                          [self.imagesCache objectForKey:key];
     });
@@ -146,8 +148,10 @@ static NSString *const kImageCacheDirectoryName = @"LRImageCache";
 - (void)diskCachedImageForKey:(NSString *)key
               completionBlock:(void (^)(UIImage *image))completionBlock
 {
+	__weak typeof(self) _weak_self = self;
     dispatch_async(self.ioQueue, ^{
-        
+		__strong typeof(_weak_self) self = _weak_self;
+		
         UIImage *diskCachedImage = [self diskCachedImageForKey:key];
         
         if (completionBlock)
@@ -218,9 +222,11 @@ static NSString *const kImageCacheDirectoryName = @"LRImageCache";
 - (void)diskCache:(UIImage *)image withKey:(NSString *)key
 {
     if (!image || !key) return;
-    
+	
+	__weak typeof(self) _weak_self = self;
     dispatch_async(self.ioQueue, ^{
-        
+		__strong typeof(_weak_self) self = _weak_self;
+    
         NSFileManager *fileManager = [NSFileManager defaultManager];
         NSString *imageCacheDirectoryPath = LRPathToImageCacheDirectory();
         
@@ -273,7 +279,10 @@ static NSString *const kImageCacheDirectoryName = @"LRImageCache";
 
 - (void)clearMemCacheForKey:(NSString *)key
 {
+	__weak typeof(self) _weak_self = self;
     dispatch_sync(self.syncQueue, ^{
+		__strong typeof(_weak_self) self = _weak_self;
+		
         [self.imagesDictionary removeObjectForKey:key];
     });
     
@@ -283,8 +292,10 @@ static NSString *const kImageCacheDirectoryName = @"LRImageCache";
 
 - (void)clearDiskCache
 {
+	__weak typeof(self) _weak_self = self;
     dispatch_async(self.ioQueue, ^{
-        
+		__strong typeof(_weak_self) self = _weak_self;
+
         NSFileManager *fileManager = [NSFileManager defaultManager];
         NSString *directoryPath = LRPathToImageCacheDirectory();
         
@@ -303,8 +314,10 @@ static NSString *const kImageCacheDirectoryName = @"LRImageCache";
 
 - (void)clearDiskCacheForKey:(NSString *)key
 {
+	__weak typeof(self) _weak_self = self;
     dispatch_async(self.ioQueue, ^{
-        
+		__strong typeof(_weak_self) self = _weak_self;
+		
         NSFileManager *fileManager = [NSFileManager defaultManager];
         NSString *filePath = LRFilePathForCacheKey(key);
         
@@ -325,8 +338,10 @@ static NSString *const kImageCacheDirectoryName = @"LRImageCache";
 {
     if (LRCacheDirectorySize() <= self.maxDirectorySize) return;
     
+	__weak typeof(self) _weak_self = self;
     dispatch_async(self.ioQueue, ^{
-        
+		__strong typeof(_weak_self) self = _weak_self;
+		
         NSDirectoryEnumerator *fileEnumerator = [[NSFileManager defaultManager] enumeratorAtPath:LRPathToImageCacheDirectory()];
         
         NSFileManager *fileManager = [NSFileManager defaultManager];

--- a/LRImageManager/LRImageManager.m
+++ b/LRImageManager/LRImageManager.m
@@ -165,7 +165,9 @@
 
             imageOperation.autoRetry = self.autoRetry;
             
+			__weak typeof(self) _weak_self = self;
             [imageOperation setCompletionBlock:^{
+				__strong typeof(_weak_self) self = _weak_self;
                 
                 [self.ongoingOperations removeObjectForKey:key];
                 

--- a/LRImageManager/LRImageOperation.m
+++ b/LRImageManager/LRImageOperation.m
@@ -247,7 +247,9 @@ completionHandler:(LRImageCompletionHandler)completionHandler
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data
 {
+	__weak typeof(self) _weak_self = self;
     dispatch_async(self.queue, ^{
+		__strong typeof(_weak_self) self = _weak_self;
         if (self.downloadedData == nil)
         {
             self.downloadedData = [[NSMutableData alloc] initWithCapacity:
@@ -306,7 +308,9 @@ completionHandler:(LRImageCompletionHandler)completionHandler
 
 - (void)postProcessImageDownload
 {
+	__weak typeof(self) _weak_self = self;
     dispatch_async(self.queue, ^{
+		__strong typeof(_weak_self) self = _weak_self;
         
         __attribute__((objc_precise_lifetime)) UIImage *imageFromData = [UIImage imageWithData:self.downloadedData];
         


### PR DESCRIPTION
We were noticing issues where even when a memory warning was triggered the memory foot print never went down or went down a trivial amount.

By removing strong references to self this problem appears to be gone. However there are still some memory showing up in the decompress image method when running instruments.

Stack overflow suggests this might be memory used by core graphics and freed separately.

Would appreciate a tag for Cocoapods, I can submit the updated pod to the spec repo if you'd like
