### PR TITLE
Xcode 6 & NSOperation state properties

### DIFF
--- a/LRImageManager/LRImageOperation.m
+++ b/LRImageManager/LRImageOperation.m
@@ -222,6 +222,7 @@ completionHandler:(LRImageCompletionHandler)completionHandler
 
 #pragma mark - NSOperation flags
 
+@synthesize executing = _executing;
 - (void)setExecuting:(BOOL)executing
 {
     [self willChangeValueForKey:@"isExecuting"];
@@ -229,6 +230,7 @@ completionHandler:(LRImageCompletionHandler)completionHandler
     [self didChangeValueForKey:@"isExecuting"];
 }
 
+@synthesize finished = _finished;
 - (void)setFinished:(BOOL)finished
 {
     [self willChangeValueForKey:@"isFinished"];
@@ -236,6 +238,7 @@ completionHandler:(LRImageCompletionHandler)completionHandler
     [self didChangeValueForKey:@"isFinished"];
 }
 
+@synthesize cancelled = _cancelled;
 - (void)setCancelled:(BOOL)cancelled
 {
     [self willChangeValueForKey:@"isCancelled"];

--- a/LRImageManager/LRImagePresenter.m
+++ b/LRImageManager/LRImagePresenter.m
@@ -154,6 +154,8 @@ static NSTimeInterval const kImageFadeAnimationTime = 0.25f;
     [self startPresentingWithCompletionBlock:NULL];
 }
 
+@synthesize cancelled = _cancelled;
+
 - (void)cancelPresenting
 {
     _cancelled = YES;


### PR DESCRIPTION
With Xcode 6 the ivars for the NSOperation state properties (`cancelled`, `executing`,...) are not properly generated as the original declarations of the properties are readonly. Manually synthesizing the properties helps.

Problem poped up in Xcode 6
