### PR TITLE
Exposing notifications when network connections are started/stopped

### DIFF
--- a/LRImageManager/LRImageCache.h
+++ b/LRImageManager/LRImageCache.h
@@ -23,6 +23,11 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+
+extern NSString * LRImageCacheDidStartLoadingImageNotification;
+extern NSString * LRImageCacheDidStopLoadingImageNotification;
+
+
 typedef NS_OPTIONS(NSUInteger, LRCacheStorageOptions)
 {
     LRCacheStorageOptionsNSDictionary = 1 << 0,

--- a/LRImageManager/LRImageCache.m
+++ b/LRImageManager/LRImageCache.m
@@ -38,6 +38,11 @@
 #define LRDispatchQueuePropertyModifier assign
 #endif
 
+
+NSString * LRImageCacheDidStartLoadingImageNotification = @"LRImageCacheDidStartLoadingImageNotification";
+NSString * LRImageCacheDidStopLoadingImageNotification  = @"LRImageCacheDidStopLoadingImageNotification";
+
+
 static const NSTimeInterval kDefaultMaxTimeInCache = 60 * 60 * 24 * 7; // 1 week
 static const unsigned long long kDefaultMaxCacheDirectorySize = 100 * 1024 * 1024; // 100 MB
 static const LRCacheStorageOptions kDefaultCacheStorageOption = LRCacheStorageOptionsNSCache;

--- a/LRImageManager/LRImageOperation.m
+++ b/LRImageManager/LRImageOperation.m
@@ -177,6 +177,8 @@ completionHandler:(LRImageCompletionHandler)completionHandler
     
     [self.connection scheduleInRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
     [self.connection start];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:LRImageCacheDidStartLoadingImageNotification object:self];
 }
 
 - (void)cancel
@@ -276,6 +278,8 @@ completionHandler:(LRImageCompletionHandler)completionHandler
     {
         [self finish];
     }
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:LRImageCacheDidStopLoadingImageNotification object:self];
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection
@@ -302,6 +306,8 @@ completionHandler:(LRImageCompletionHandler)completionHandler
             [self postProcessImageDownload];
         }
     };
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:LRImageCacheDidStopLoadingImageNotification object:self];
 }
 
 - (void)postProcessImageDownload


### PR DESCRIPTION
In some scenarios it's necessary to expose the information when a network connections starts or ends. For example when using an own networking activity indicator.

Therefore I've added notifications to `LRImageOperation` whenever the connection is started, finishes or fails that can be forwarded.
