### PR TITLE
fix compilation when using LRImageManager in a swift project

### DIFF
--- a/LRImageManager/LRImageCache.h
+++ b/LRImageManager/LRImageCache.h
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef NS_OPTIONS(NSUInteger, LRCacheStorageOptions)
 {


### PR DESCRIPTION
There isn't a UIKit import in a pch header as in Objective-C so this fails unless you import it there.
